### PR TITLE
Set TEMPLATES_AUTO_RELOAD by default

### DIFF
--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -30,6 +30,7 @@ def cli(app, *, freezer=None, base_url=None):
         freezer = Freezer(app)
 
     inject_cname(app)
+    app.config.setdefault('TEMPLATES_AUTO_RELOAD', True)
 
     @click.group(context_settings=dict(help_option_names=['-h', '--help']),
                  help=__doc__)


### PR DESCRIPTION
Flask defaults to False because it's slower, but elsa apps are only
served for debugging. Speed isn't that important when freezing.

Fixes https://github.com/pyvec/elsa/issues/5