### PR TITLE
Set template auto_reload flag directly in serve mode

### DIFF
--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -32,7 +32,6 @@ def cli(app, *, freezer=None, base_url=None):
         freezer = Freezer(app)
 
     inject_cname(app)
-    app.config.setdefault('TEMPLATES_AUTO_RELOAD', True)
 
     @click.group(context_settings=dict(help_option_names=['-h', '--help']),
                  help=__doc__)
@@ -44,6 +43,8 @@ def cli(app, *, freezer=None, base_url=None):
                   help='Port to listen at')
     def serve(port):
         """Run a debug server"""
+        if app.config.get('TEMPLATES_AUTO_RELOAD') is not False:
+            app.jinja_env.auto_reload = True
         app.run(host='0.0.0.0', port=port, debug=True)
 
     @command.command()


### PR DESCRIPTION
Auto reloading does not work correctly when Jinja environment is initialized before elsa's cli() is called (for example when adding template filters - see #8). Flask's TEMPLATES_AUTO_RELOAD normally propagates to auto_reload property of Jinja's environment which can be set in runtime, so try to keep this behaviour in elsa's serve mode.

Fixes #8.