### PR TITLE
Add a __shutdown__ route for easier testing

### DIFF
--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -2,11 +2,11 @@ import os
 import urllib.parse
 import warnings
 
-from flask_frozen import Freezer
 from flask import Response
 import click
 
 from ._deployment import deploy as deploy_
+from ._shutdown import ShutdownableFreezer, inject_shutdown
 
 
 def port_option():
@@ -50,7 +50,7 @@ def inject_cname(app):
 def cli(app, *, freezer=None, base_url=None):
     """Get a cli() function for provided app"""
     if not freezer:
-        freezer = Freezer(app)
+        freezer = ShutdownableFreezer(app)
 
     @click.group(context_settings=dict(help_option_names=['-h', '--help']),
                  help=__doc__)
@@ -68,6 +68,7 @@ def cli(app, *, freezer=None, base_url=None):
         if auto_reload or auto_reload is None:
             app.jinja_env.auto_reload = True
 
+        inject_shutdown(app)
         if cname:
             inject_cname(app)
 

--- a/elsa/_shutdown.py
+++ b/elsa/_shutdown.py
@@ -1,0 +1,42 @@
+from flask import request
+from flask_frozen import Freezer
+
+
+PATH = '/__shutdown__/'
+
+
+def shutdown_server():
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+
+
+def shutdown_response():
+    shutdown_server()
+    return 'Server shutting down...'
+
+
+def inject_shutdown(app):
+    """Create a shutdown route in given app"""
+    @app.route(PATH, methods=['POST'])
+    def shutdown():
+        return shutdown_response()
+
+
+class ShutdownableFreezer(Freezer):
+    """
+    Like Freezer from Frozen-Flask, but can be shut down while serving
+    via HTTP POST
+    """
+    def make_static_app(self):
+        app = super().make_static_app()
+        old_dispatch_request = app.dispatch_request
+
+        def dispatch_request():
+            if request.path == PATH and request.method == 'POST':
+                return shutdown_response()
+            return old_dispatch_request()
+
+        app.dispatch_request = dispatch_request
+        return app

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Especially on Windows, sending Ctrl+C to the elsa process was tricky.
Windows, Mac and Linux tests now pass.

Related https://github.com/pyvec/elsa/issues/20

The route is available unconditionally as an undocumented feature.