### PR TITLE
Travis CI: Build on OS X as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,28 @@ python:
 - '3.5'
 - '3.6'
 - 'nightly'
+matrix:
+  include:
+    - os: osx
+      sudo: required
+      language: generic
+      python: 3.6
+      env:
+      - TRAVIS_PYTHON_VERSION: 3.6
+  allow_failures:
+    - os: osx
+  fast_finish: true
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION/bin
-install:
-    - pip install --upgrade tox tox-travis
+install: |
+  if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      brew update;
+      brew install python3;
+      python3 -m pip install --upgrade tox tox-travis
+  else
+      pip install --upgrade tox tox-travis
+  fi
 script: tox


### PR DESCRIPTION
Python is not officially supported on Mac on Travis, so we fetch
it from homebrew, where only the latest version is available.

It takes quite some time before the test run starts, so I've
marked it with allow_failures and fast_finish not the slow
down the general result from Travis CI. This means a Mac
failure would not render the commit/PR red, but it's still
better than without Mac CI.

**Doing this as PR just to test AppVeyor** (I would push it to master directly otherwise).