### PR TITLE
A way of reusing the elsa cli

### DIFF
--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -58,7 +58,7 @@ def inject_cname(app):
 def cli(app, *, freezer=None, base_url=None, invoke_cli=True):
     """ Generates command-line interface for the provided app.
 
-    If ``invoke_cli`` is set to ``True`` (the dafulat),
+    If ``invoke_cli`` is set to ``True`` (the default),
     the cli is invoked right away,
     otherwise it's returned so it can be used further.
     """

--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -55,7 +55,7 @@ def inject_cname(app):
                         mimetype='application/octet-stream')
 
 
-def cli(app, *, freezer=None, base_url=None):
+def cli(app, *, freezer=None, base_url=None, invoke_cli=True):
     """Get a cli() function for provided app"""
     if not freezer:
         freezer = ShutdownableFreezer(app)
@@ -139,4 +139,7 @@ def cli(app, *, freezer=None, base_url=None):
 
         deploy_(path, remote=remote, push=push, show_err=show_git_push_stderr)
 
-    return command()
+    if invoke_cli:
+        return command()
+    else:
+        return command

--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -58,7 +58,8 @@ def inject_cname(app):
 def cli(app, *, freezer=None, base_url=None, invoke_cli=True):
     """ Generates command-line interface for the provided app.
 
-    If ``invoke_cli`` is set to ``True``, the cli is invoked right away,
+    If ``invoke_cli`` is set to ``True`` (the dafulat),
+    the cli is invoked right away,
     otherwise it's returned so it can be used further.
     """
     if not freezer:

--- a/elsa/_cli.py
+++ b/elsa/_cli.py
@@ -56,7 +56,11 @@ def inject_cname(app):
 
 
 def cli(app, *, freezer=None, base_url=None, invoke_cli=True):
-    """Get a cli() function for provided app"""
+    """ Generates command-line interface for the provided app.
+
+    If ``invoke_cli`` is set to ``True``, the cli is invoked right away,
+    otherwise it's returned so it can be used further.
+    """
     if not freezer:
         freezer = ShutdownableFreezer(app)
 

--- a/tests/fixtures/custom_command.py
+++ b/tests/fixtures/custom_command.py
@@ -1,0 +1,21 @@
+import click
+from flask import Flask
+
+
+app = Flask('custom_command')
+
+
+@app.route('/')
+def index():
+    return '<html><body>SUCCESS</body></html>'
+
+
+if __name__ == '__main__':
+    from elsa import cli
+    elsa = cli(app, base_url='https://example.org', invoke_cli=False)
+
+    @elsa.command()
+    def custom_command():
+        click.echo("Custom command")
+
+    elsa()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -79,7 +79,7 @@ class ElsaRunner:
             cr = subprocess.run(
                 self.create_command(command, script), check=not should_fail,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
             )
         except subprocess.CalledProcessError as e:
             raise CommandFailed('return code was {}'.format(e.returncode))


### PR DESCRIPTION
I want to add a command to naucse, however, elsa invokes the cli right away and I couldn't way a way to "subclass" the cli other than this one.

The following is an example from naucse, when this function is called, all three commands from elsa and the ``new_command`` are available from command line.

```
import elsa
import click

def cli(app, *, base_url=None, freezer=None):
    elsa_group = elsa.cli(app, base_url=base_url, freezer=freezer, invoke_cli=False)

    @click.group()
    def naucse():
        pass

    @naucse.command()
    def new_command():
        """ Some new command. """

    cli = click.CommandCollection(sources=[naucse, elsa_group])

    return cli()
```