### PR TITLE
Add --verbose flag to print out page names as they're frozen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'click',
         'Flask',
-        'Frozen-Flask >= 0.14',
+        'Frozen-Flask >= 0.15',
         'ghp-import',
     ],
     setup_requires=['pytest-runner'],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -474,3 +474,9 @@ def test_invoke_cli(elsa):
     result = elsa.run('custom_command', script='custom_command.py')
 
     assert result.stdout.strip() == 'Custom command'
+
+
+def test_freeze_verbose(elsa, capsys):
+    elsa.run('freeze', '--verbose')
+    captured = capsys.readouterr()
+    assert 'Frozen /' in captured.err.splitlines()


### PR DESCRIPTION
This might make things a tiny bit easier to debug... But mainly, it allows producing output while freezing a large site, so the process doesn't appear hung.