### PR TITLE
Support CircleCI

### DIFF
--- a/elsa/_deployment.py
+++ b/elsa/_deployment.py
@@ -37,13 +37,19 @@ def get_git_toplevel():
 
 def deploy(html_dir, *, remote, push, show_err):
     """Deploy to GitHub pages, expects to be already frozen"""
-    if os.environ.get('TRAVIS'):  # Travis CI
+    if os.environ.get('CI'):
         print('Setting up git...')
         run(['git', 'config', 'user.name', get_last_commit_info('%cN')])
         run(['git', 'config', 'user.email', get_last_commit_info('%cE')])
+        
+        if os.environ.get('TRAVIS'):
+            repo_slug = os.environ.get('TRAVIS_REPO_SLUG')
+        elif os.environ.get('CIRCLECI'):
+            repo_slug = '{}/{}'.format(os.environ.get('CIRCLE_PROJECT_USERNAME'), os.environ.get('CIRCLE_PROJECT_REPONAME'))
+        else:
+            raise RuntimeError('Unsupported CI')
 
-        github_token = os.environ.get('GITHUB_TOKEN')  # from .travis.yml
-        repo_slug = os.environ.get('TRAVIS_REPO_SLUG')
+        github_token = os.environ.get('GITHUB_TOKEN')
         rurl = 'https://{}@github.com/{}.git'.format(github_token, repo_slug)
         run(['git', 'remote', 'set-url', remote, rurl])
 


### PR DESCRIPTION
Currently Elsa is hardcoded for Travis CI. This is my attempt to bring support for CircleCI. I didn't test it - it's my best guess and I made it editing a file here using GitHub's pencil feature 🙀 

See https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables for a reference and https://circleci.com/gh/pyvec/pyvec.org/15#build-parameters/containers/0 (Spin Up Environment) for examples:

```
  BASH_ENV=/tmp/.bash_env-5d614082be728d64db773f33-0-build
  CI=true
  CIRCLECI=true
  CIRCLE_BRANCH=honzajavorek/members
  CIRCLE_BUILD_NUM=15
  CIRCLE_BUILD_URL=https://circleci.com/gh/pyvec/pyvec.org/15
  CIRCLE_COMPARE_URL=
  CIRCLE_JOB=build
  CIRCLE_NODE_INDEX=0
  CIRCLE_NODE_TOTAL=1
  CIRCLE_PREVIOUS_BUILD_NUM=14
  CIRCLE_PROJECT_REPONAME=pyvec.org
  CIRCLE_PROJECT_USERNAME=pyvec
  CIRCLE_PULL_REQUEST=https://github.com/pyvec/pyvec.org/pull/85
  CIRCLE_PULL_REQUESTS=https://github.com/pyvec/pyvec.org/pull/85
  CIRCLE_REPOSITORY_URL=git@github.com:pyvec/pyvec.org.git
  CIRCLE_SHA1=f6e04550035d3f904014689ee8f1541346b5feaf
  CIRCLE_SHELL_ENV=/tmp/.bash_env-5d614082be728d64db773f33-0-build
  CIRCLE_STAGE=build
  CIRCLE_USERNAME=honzajavorek
  CIRCLE_WORKFLOW_ID=e8affa4d-f267-4930-b339-af510fc8f849
  CIRCLE_WORKFLOW_JOB_ID=ce6ad044-09a4-4d4e-8423-ce085a50be0b
  CIRCLE_WORKFLOW_UPSTREAM_JOB_IDS=
  CIRCLE_WORKFLOW_WORKSPACE_ID=e8affa4d-f267-4930-b339-af510fc8f849
  CIRCLE_WORKING_DIRECTORY=~/repo
  CI_PULL_REQUEST=https://github.com/pyvec/pyvec.org/pull/85
  CI_PULL_REQUESTS=https://github.com/pyvec/pyvec.org/pull/85
```