### PR TITLE
Add --host option for serving and use Flask default if not specified 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,7 @@
 environment:
   matrix:
-  - TOXENV: "py35"
-  - TOXENV: "py36"
   - TOXENV: "py37"
+  - TOXENV: "py38"
 
 install:
   - C:\Python35\python -m pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 - 'pypy3.5-5.9.0'
 - 'nightly'
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
     - os: osx
       sudo: required
       language: generic
-      python: 3.7
+      python: 3.8
       env:
-      - TRAVIS_PYTHON_VERSION: 3.7
+      - TRAVIS_PYTHON_VERSION: 3.8
   allow_failures:
     - python: nightly
   fast_finish: true

--- a/QUICKSTART.rst
+++ b/QUICKSTART.rst
@@ -102,7 +102,7 @@ Now run your website on your own computer like this:
 .. code-block:: bash
 
     (__env__)$ python website.py serve
-     * Running on http://0.0.0.0:8003/ (Press CTRL+C to quit)
+     * Running on http://127.0.0.1:8003/ (Press CTRL+C to quit)
      * Restarting with stat
      * Debugger is active!
      * Debugger pin code: 237-729-566

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -295,7 +295,7 @@ def test_host(elsa, host, serve_command):
         *serve_command, '--host', host, '--port', port,
         assert_running_on='http://{}:{}/'.format(host, port),
     ):
-        url = 'http://{}:{}/'.format(host, port)
+        url = 'http://localhost:{}/'.format(port)
         assert 'SUCCESS' in requests.get(url).text
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -84,11 +84,13 @@ class ElsaRunner:
                 universal_newlines=True,
             )
         except subprocess.CalledProcessError as e:
+            sys.stdout.write(e.stdout)
+            sys.stderr.write(e.stderr)
             raise CommandFailed('return code was {}'.format(e.returncode))
-        if should_fail and cr.returncode == 0:
-            raise CommandNotFailed('return code was 0')
         sys.stdout.write(cr.stdout)
         sys.stderr.write(cr.stderr)
+        if should_fail and cr.returncode == 0:
+            raise CommandNotFailed('return code was 0')
         return cr
 
     @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [tox]
-envlist = py35,py36,py37,pypy3
+envlist = py35,py36,py37,py38,py39,pypy3
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
As mentioned in Flask docs, "0.0.0.0" should be used for externally
visible servers. It is not a good default for security reasons.

Change the default to Flask's own default (currently 127.0.0.1), and provide
a --host option to change it.

I'm also adding some test improvements (though one batch is left in the big commit). Let me know if I should make separate PRs.

Unfortunately, there's no easy way to test the difference between
binding to 127.0.0.1 and 0.0.0.0. That would requite knowing an
external IP of the current machine, and possibly opening up firewalls.

Related to: https://github.com/pyvec/elsa/issues/66
